### PR TITLE
Implement core utilities and orchestrator

### DIFF
--- a/lucas_project/core/__init__.py
+++ b/lucas_project/core/__init__.py
@@ -1,1 +1,23 @@
-"""Core utilities for Lucas project."""
+"""Public core helpers for the Lucas project."""
+
+from .config import Settings, get_settings
+from .db import get_db
+from .llm_cache import LLMCache, cache, get_cache
+from .orchestrator import broadcaster, register_job, scheduler
+from .utils import circuit_breaker, get_logger, rate_limiter, retry
+
+__all__ = [
+    "Settings",
+    "get_settings",
+    "get_db",
+    "LLMCache",
+    "get_cache",
+    "cache",
+    "rate_limiter",
+    "retry",
+    "get_logger",
+    "circuit_breaker",
+    "scheduler",
+    "broadcaster",
+    "register_job",
+]

--- a/lucas_project/core/config.py
+++ b/lucas_project/core/config.py
@@ -1,0 +1,25 @@
+"""Application configuration using Pydantic settings."""
+
+from functools import lru_cache
+from pathlib import Path
+
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Configuration values for the application."""
+
+    debug: bool = False
+    database_url: str = "./lucas.db"
+    llm_cache_path: Path = Path("./lucas_project/data/llm_cache.json")
+    scheduler_timezone: str = "UTC"
+
+    class Config:
+        env_prefix = "LUCAS_"
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    """Return a cached :class:`Settings` instance."""
+
+    return Settings()

--- a/lucas_project/core/db.py
+++ b/lucas_project/core/db.py
@@ -1,0 +1,22 @@
+"""Async database helpers using :mod:`aiosqlite`."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+
+import aiosqlite
+
+from .config import get_settings
+
+
+@asynccontextmanager
+async def get_db() -> aiosqlite.Connection:
+    """Yield an aiosqlite connection configured with row factory."""
+
+    settings = get_settings()
+    db = await aiosqlite.connect(settings.database_url)
+    db.row_factory = aiosqlite.Row
+    try:
+        yield db
+    finally:
+        await db.close()

--- a/lucas_project/core/llm_cache.py
+++ b/lucas_project/core/llm_cache.py
@@ -1,0 +1,49 @@
+"""Simple JSON-based cache for LLM responses."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .config import get_settings
+
+
+class LLMCache:
+    """Disk backed JSON cache."""
+
+    def __init__(self, path: Path | None = None) -> None:
+        settings = get_settings()
+        self.path = path or settings.llm_cache_path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        if not self.path.exists():
+            self.path.write_text("{}", encoding="utf-8")
+
+    def _read(self) -> dict[str, Any]:
+        with self.path.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+
+    def _write(self, data: dict[str, Any]) -> None:
+        with self.path.open("w", encoding="utf-8") as fh:
+            json.dump(data, fh, ensure_ascii=False, indent=2)
+
+    def lookup(self, key: str) -> Any | None:
+        """Return cached value for ``key`` or ``None``."""
+
+        return self._read().get(key)
+
+    def store(self, key: str, value: Any) -> None:
+        """Store ``value`` under ``key``."""
+
+        data = self._read()
+        data[key] = value
+        self._write(data)
+
+
+def get_cache(path: Path | None = None) -> LLMCache:
+    """Return a cache instance."""
+
+    return LLMCache(path)
+
+
+cache = LLMCache()

--- a/lucas_project/core/orchestrator.py
+++ b/lucas_project/core/orchestrator.py
@@ -1,0 +1,52 @@
+"""Task orchestration and websocket broadcasting."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any, Set
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from fastapi import WebSocket
+
+scheduler = AsyncIOScheduler()
+scheduler.start()
+
+
+class WebSocketBroadcaster:
+    """Manage websocket connections and broadcast messages."""
+
+    def __init__(self) -> None:
+        self.connections: Set[WebSocket] = set()
+
+    async def connect(self, websocket: WebSocket) -> None:
+        """Accept and register a websocket connection."""
+
+        await websocket.accept()
+        self.connections.add(websocket)
+
+    def disconnect(self, websocket: WebSocket) -> None:
+        """Remove a websocket connection."""
+
+        self.connections.discard(websocket)
+
+    async def broadcast(self, message: str) -> None:
+        """Send ``message`` to all active connections."""
+
+        for ws in list(self.connections):
+            try:
+                await ws.send_text(message)
+            except Exception:
+                self.disconnect(ws)
+
+
+broadcaster = WebSocketBroadcaster()
+
+
+def register_job(*, trigger: str = "interval", **trigger_args: Any) -> Callable[[Callable[..., Awaitable[Any]]], Callable[..., Awaitable[Any]]]:
+    """Register an async function as a scheduled job."""
+
+    def decorator(func: Callable[..., Awaitable[Any]]) -> Callable[..., Awaitable[Any]]:
+        scheduler.add_job(func, trigger, **trigger_args)
+        return func
+
+    return decorator

--- a/lucas_project/core/utils.py
+++ b/lucas_project/core/utils.py
@@ -1,0 +1,103 @@
+"""Shared utility helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from functools import wraps
+from typing import ParamSpec, TypeVar
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a configured logger with the given name."""
+
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(
+            "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+        )
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+    logger.propagate = False
+    return logger
+
+
+def rate_limiter(max_calls: int, period: float) -> Callable[[Callable[P, Awaitable[R]]], Callable[P, Awaitable[R]]]:
+    """Rate limit calls to an async function."""
+
+    semaphore = asyncio.Semaphore(max_calls)
+    interval = period / max_calls
+
+    def decorator(func: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable[R]]:
+        @wraps(func)
+        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            async with semaphore:
+                result = await func(*args, **kwargs)
+                await asyncio.sleep(interval)
+                return result
+
+        return wrapper
+
+    return decorator
+
+
+def retry(retries: int = 3, backoff: float = 1.0) -> Callable[[Callable[P, Awaitable[R]]], Callable[P, Awaitable[R]]]:
+    """Retry an async function on failure using exponential backoff."""
+
+    def decorator(func: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable[R]]:
+        @wraps(func)
+        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            attempt = 0
+            while True:
+                try:
+                    return await func(*args, **kwargs)
+                except Exception:  # pragma: no cover - thin wrapper
+                    attempt += 1
+                    if attempt > retries:
+                        raise
+                    await asyncio.sleep(backoff * attempt)
+
+        return wrapper
+
+    return decorator
+
+
+def circuit_breaker(
+    max_failures: int, reset_timeout: float
+) -> Callable[[Callable[P, Awaitable[R]]], Callable[P, Awaitable[R]]]:
+    """Simple circuit breaker for async functions."""
+
+    def decorator(func: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable[R]]:
+        failures = 0
+        opened_at: float | None = None
+
+        @wraps(func)
+        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            nonlocal failures, opened_at
+            loop = asyncio.get_event_loop()
+            now = loop.time()
+
+            if opened_at and now - opened_at < reset_timeout:
+                raise RuntimeError("Circuit breaker open")
+            if opened_at and now - opened_at >= reset_timeout:
+                failures = 0
+                opened_at = None
+
+            try:
+                result = await func(*args, **kwargs)
+                failures = 0
+                return result
+            except Exception:
+                failures += 1
+                if failures >= max_failures:
+                    opened_at = loop.time()
+                raise
+
+        return wrapper
+
+    return decorator

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 """Entry point for the Lucas project."""
 
-from lucas_project.core import *  # noqa: F401
+from lucas_project.core import *  # noqa: F401,F403
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- implement configuration settings helper
- add aiosqlite DB context
- create general utility decorators and logger factory
- implement disk-based LLM cache
- implement task orchestrator and websocket broadcaster
- re-export helpers from `core.__init__`
- adjust `main.py` to satisfy linter

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844e89a68d0832098190c105efcdfab