### PR TITLE
Add token bucket rate limiter

### DIFF
--- a/lucas_project/core/__init__.py
+++ b/lucas_project/core/__init__.py
@@ -4,7 +4,7 @@ from .config import Settings, get_settings
 from .db import get_db
 from .llm_cache import LLMCache, cache, get_cache
 from .orchestrator import broadcaster, register_job, scheduler
-from .utils import circuit_breaker, get_logger, rate_limiter, retry
+from .utils import circuit_breaker, get_logger, rate_limiter, retry, token_bucket
 
 __all__ = [
     "Settings",
@@ -14,6 +14,7 @@ __all__ = [
     "get_cache",
     "cache",
     "rate_limiter",
+    "token_bucket",
     "retry",
     "get_logger",
     "circuit_breaker",


### PR DESCRIPTION
## Summary
- add asynchronous token bucket rate limiter
- expose `token_bucket` from core package

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844f0794fe08320b06f3c0181f7ce63