### PR TITLE
Add Python artifacts to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.venv/
+__pycache__/
+*.pyc
+.ruff_cache/
+.pytest_cache/


### PR DESCRIPTION
## Summary
- ignore Python artifacts such as `.venv/`, `__pycache__/`, `*.pyc`, `.ruff_cache/`, and `.pytest_cache/`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844f5f151bc8320ba326534964dfdd2