### PR TITLE
Implement database schema with Alembic

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,26 @@
+[alembic]
+script_location = lucas_project/alembic
+sqlalchemy.url = sqlite:///lucas.db
+
+[loggers]
+keys = root
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+

--- a/lucas_project/alembic/env.py
+++ b/lucas_project/alembic/env.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from logging.config import fileConfig
+
+from alembic import context
+
+from lucas_project.core.config import get_settings
+from lucas_project.core.models import Base
+from lucas_project.core.db import get_engine
+
+config = context.config
+fileConfig(config.config_file_name)
+
+
+def run_migrations_offline() -> None:
+    url = f"sqlite:///{get_settings().database_url}"
+    context.configure(url=url, target_metadata=Base.metadata, literal_binds=True)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = get_engine()
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=Base.metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()
+

--- a/lucas_project/alembic/versions/0001_initial.py
+++ b/lucas_project/alembic/versions/0001_initial.py
@@ -1,0 +1,75 @@
+"""Initial schema"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "trend_seeds",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("phrase", sa.String, unique=True, nullable=False),
+    )
+    op.create_table(
+        "domains",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("domain", sa.String, unique=True, nullable=False, index=True),
+        sa.Column("trend_seed_id", sa.Integer, sa.ForeignKey("trend_seeds.id")),
+        sa.Column("status", sa.String, nullable=False, server_default="new"),
+        sa.Column("created_at", sa.DateTime, nullable=False, server_default=sa.func.now()),
+    )
+    op.create_table(
+        "availability_checks",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("domain_id", sa.Integer, sa.ForeignKey("domains.id"), nullable=False),
+        sa.Column("checked_at", sa.DateTime, nullable=False, server_default=sa.func.now()),
+        sa.Column("available", sa.Boolean, nullable=False),
+    )
+    op.create_table(
+        "valuations",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("domain_id", sa.Integer, sa.ForeignKey("domains.id"), nullable=False),
+        sa.Column("service", sa.String, nullable=False),
+        sa.Column("value", sa.Float, nullable=False),
+        sa.Column("created_at", sa.DateTime, nullable=False, server_default=sa.func.now()),
+    )
+    op.create_table(
+        "monitors",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("domain_id", sa.Integer, sa.ForeignKey("domains.id"), nullable=False),
+        sa.Column("service", sa.String, nullable=False),
+        sa.Column("monitor_ref", sa.String, nullable=False),
+    )
+    op.create_table(
+        "backorders",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("domain_id", sa.Integer, sa.ForeignKey("domains.id"), nullable=False),
+        sa.Column("provider", sa.String, nullable=False),
+        sa.Column("ordered_at", sa.DateTime, nullable=False, server_default=sa.func.now()),
+    )
+    op.create_table(
+        "listings",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("domain_id", sa.Integer, sa.ForeignKey("domains.id"), nullable=False),
+        sa.Column("marketplace", sa.String, nullable=False),
+        sa.Column("url", sa.String),
+        sa.Column("status", sa.String, nullable=False, server_default="pending"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("listings")
+    op.drop_table("backorders")
+    op.drop_table("monitors")
+    op.drop_table("valuations")
+    op.drop_table("availability_checks")
+    op.drop_table("domains")
+    op.drop_table("trend_seeds")

--- a/lucas_project/core/db.py
+++ b/lucas_project/core/db.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from contextlib import asynccontextmanager
 
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+
 import aiosqlite
 
 from .config import get_settings
@@ -20,3 +23,10 @@ async def get_db() -> aiosqlite.Connection:
         yield db
     finally:
         await db.close()
+
+
+def get_engine() -> Engine:
+    """Return a synchronous SQLAlchemy engine for migrations."""
+
+    settings = get_settings()
+    return create_engine(f"sqlite:///{settings.database_url}")

--- a/lucas_project/core/models.py
+++ b/lucas_project/core/models.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, Float, ForeignKey, String
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+
+
+class Base(DeclarativeBase):
+    """Base declarative class."""
+
+
+class TrendSeed(Base):
+    __tablename__ = "trend_seeds"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    phrase: Mapped[str] = mapped_column(String, unique=True)
+
+    domains: Mapped[list["Domain"]] = relationship(back_populates="trend_seed")
+
+
+class Domain(Base):
+    __tablename__ = "domains"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    domain: Mapped[str] = mapped_column(String, unique=True, index=True)
+    trend_seed_id: Mapped[int | None] = mapped_column(ForeignKey("trend_seeds.id"))
+    status: Mapped[str] = mapped_column(String, default="new")
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    trend_seed: Mapped[TrendSeed | None] = relationship(back_populates="domains")
+    availability_checks: Mapped[list["AvailabilityCheck"]] = relationship(
+        back_populates="domain"
+    )
+    valuations: Mapped[list["Valuation"]] = relationship(back_populates="domain")
+    monitors: Mapped[list["Monitor"]] = relationship(back_populates="domain")
+    backorders: Mapped[list["Backorder"]] = relationship(back_populates="domain")
+    listings: Mapped[list["Listing"]] = relationship(back_populates="domain")
+
+
+class AvailabilityCheck(Base):
+    __tablename__ = "availability_checks"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    domain_id: Mapped[int] = mapped_column(ForeignKey("domains.id"))
+    checked_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    available: Mapped[bool] = mapped_column(Boolean)
+
+    domain: Mapped[Domain] = relationship(back_populates="availability_checks")
+
+
+class Valuation(Base):
+    __tablename__ = "valuations"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    domain_id: Mapped[int] = mapped_column(ForeignKey("domains.id"))
+    service: Mapped[str] = mapped_column(String)
+    value: Mapped[float] = mapped_column(Float)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    domain: Mapped[Domain] = relationship(back_populates="valuations")
+
+
+class Monitor(Base):
+    __tablename__ = "monitors"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    domain_id: Mapped[int] = mapped_column(ForeignKey("domains.id"))
+    service: Mapped[str] = mapped_column(String)
+    monitor_ref: Mapped[str] = mapped_column(String)
+
+    domain: Mapped[Domain] = relationship(back_populates="monitors")
+
+
+class Backorder(Base):
+    __tablename__ = "backorders"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    domain_id: Mapped[int] = mapped_column(ForeignKey("domains.id"))
+    provider: Mapped[str] = mapped_column(String)
+    ordered_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    domain: Mapped[Domain] = relationship(back_populates="backorders")
+
+
+class Listing(Base):
+    __tablename__ = "listings"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    domain_id: Mapped[int] = mapped_column(ForeignKey("domains.id"))
+    marketplace: Mapped[str] = mapped_column(String)
+    url: Mapped[str | None] = mapped_column(String, nullable=True)
+    status: Mapped[str] = mapped_column(String, default="pending")
+
+    domain: Mapped[Domain] = relationship(back_populates="listings")
+

--- a/lucas_project/core/orchestrator.py
+++ b/lucas_project/core/orchestrator.py
@@ -9,7 +9,11 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from fastapi import WebSocket
 
 scheduler = AsyncIOScheduler()
-scheduler.start()
+try:
+    scheduler.start()
+except RuntimeError:
+    # scheduler may be imported without an event loop (e.g. during migrations)
+    pass
 
 
 class WebSocketBroadcaster:

--- a/lucas_project/modules/2_domain_generator.py
+++ b/lucas_project/modules/2_domain_generator.py
@@ -1,0 +1,27 @@
+"""Domain generator module."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Iterable
+
+from lucas_project.core import get_logger, register_job
+
+logger = get_logger(__name__)
+
+
+def generate_domains(trends: Iterable[str]) -> list[str]:
+    """Generate candidate domain names from trending phrases."""
+
+    return [f"{trend.replace(' ', '')}.com" for trend in trends]
+
+
+@register_job(trigger="interval", minutes=60)
+async def run() -> None:
+    """Generate domains using discovered trends."""
+
+    await asyncio.sleep(0)
+    trends = ["example"]
+    domains = generate_domains(trends)
+    logger.info("Generated domains: %s", domains)
+

--- a/lucas_project/modules/__init__.py
+++ b/lucas_project/modules/__init__.py
@@ -1,1 +1,13 @@
 """Domain modules for Lucas project."""
+
+from importlib import import_module
+
+MODULES = [
+    "lucas_project.modules.1_trend_discovery",
+    "lucas_project.modules.2_domain_generator",
+]
+
+for mod in MODULES:
+    import_module(mod)
+
+


### PR DESCRIPTION
## Summary
- add SQLAlchemy models for domain management
- provide an Alembic environment and initial schema migration
- expose `get_engine` helper in database utils
- load modules automatically
- make scheduler import safe
- add domain generation module

## Testing
- `ruff check .`
- `pytest -q`
- `PYTHONPATH=. alembic upgrade head`

------
https://chatgpt.com/codex/tasks/task_e_6844f7266c288320a812d7d2e635df84