### PR TITLE
Fix critical issues and improve reliability

### DIFF
--- a/lucas_project/core/models.py
+++ b/lucas_project/core/models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import Boolean, DateTime, Float, ForeignKey, String
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
@@ -26,7 +26,7 @@ class Domain(Base):
     domain: Mapped[str] = mapped_column(String, unique=True, index=True)
     trend_seed_id: Mapped[int | None] = mapped_column(ForeignKey("trend_seeds.id"))
     status: Mapped[str] = mapped_column(String, default="new")
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
 
     trend_seed: Mapped[TrendSeed | None] = relationship(back_populates="domains")
     availability_checks: Mapped[list["AvailabilityCheck"]] = relationship(
@@ -43,7 +43,7 @@ class AvailabilityCheck(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     domain_id: Mapped[int] = mapped_column(ForeignKey("domains.id"))
-    checked_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    checked_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
     available: Mapped[bool] = mapped_column(Boolean)
 
     domain: Mapped[Domain] = relationship(back_populates="availability_checks")
@@ -56,7 +56,7 @@ class Valuation(Base):
     domain_id: Mapped[int] = mapped_column(ForeignKey("domains.id"))
     service: Mapped[str] = mapped_column(String)
     value: Mapped[float] = mapped_column(Float)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
 
     domain: Mapped[Domain] = relationship(back_populates="valuations")
 
@@ -78,7 +78,7 @@ class Backorder(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     domain_id: Mapped[int] = mapped_column(ForeignKey("domains.id"))
     provider: Mapped[str] = mapped_column(String)
-    ordered_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    ordered_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
 
     domain: Mapped[Domain] = relationship(back_populates="backorders")
 

--- a/lucas_project/core/utils.py
+++ b/lucas_project/core/utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from collections.abc import Awaitable, Callable
 from functools import wraps
 from typing import ParamSpec, TypeVar
@@ -32,14 +33,21 @@ def rate_limiter(max_calls: int, period: float) -> Callable[[Callable[P, Awaitab
 
     semaphore = asyncio.Semaphore(max_calls)
     interval = period / max_calls
+    last_called = 0.0
+    lock = asyncio.Lock()
 
     def decorator(func: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable[R]]:
         @wraps(func)
         async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            nonlocal last_called
             async with semaphore:
-                result = await func(*args, **kwargs)
-                await asyncio.sleep(interval)
-                return result
+                async with lock:
+                    now = asyncio.get_event_loop().time()
+                    wait_time = interval - (now - last_called)
+                    if wait_time > 0:
+                        await asyncio.sleep(wait_time)
+                    last_called = asyncio.get_event_loop().time()
+            return await func(*args, **kwargs)
 
         return wrapper
 
@@ -53,11 +61,11 @@ class TokenBucket:
         self.capacity = rate
         self.tokens = float(rate)
         self.rate_per_sec = rate / per
-        self.updated_at = asyncio.get_event_loop().time()
+        self.updated_at = time.monotonic()
         self.lock = asyncio.Lock()
 
     def _refill(self) -> None:
-        now = asyncio.get_event_loop().time()
+        now = time.monotonic()
         elapsed = now - self.updated_at
         self.updated_at = now
         self.tokens = min(self.capacity, self.tokens + elapsed * self.rate_per_sec)

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 """Entry point for the Lucas project."""
 
-from lucas_project.core import *  # noqa: F401,F403
+# Import the scheduler to ensure scheduled jobs are registered on startup.
+from lucas_project.core import scheduler  # noqa: F401
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- avoid wildcard import in `main.py`
- improve `rate_limiter` and `TokenBucket`
- add logging for scheduler startup and websocket failures
- sanitize domain generation and use timezone-aware datetimes
- make cache thread-safe
- replace deprecated `datetime.utcnow` usage
- update tests to pass

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845c63955088320b902ae7792bedc70