### PR TITLE
Install pytest-asyncio

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ sqlalchemy~=2.0
 alembic~=1.13
 ruff~=0.4
 pytest~=8.2
+pytest-asyncio~=0.23.5
 python-multipart~=0.0.7
 sentence-transformers~=2.3
 pydantic-settings~=2.2


### PR DESCRIPTION
## Summary
- install `pytest-asyncio` to enable async pytest tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6845ccf5604483209ac6aafe99e6e845