### PR TITLE
Integrate HumbleWorth valuation API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
 # Environment configuration for the Lucas project
 # Copy to .env and fill in actual values
+
+# Optional API key for HumbleWorth valuations (currently not required)
+LUCAS_HUMBLEWORTH_API_KEY=

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The most important ones are:
 | `LUCAS_GITHUB_TOKEN` | Optional GitHub token used when fetching trending repositories. |
 | `LUCAS_WHOIS_API_KEY` | API key for WHOIS lookups. |
 | `LUCAS_ESTIBOT_API_KEY` | API key for EstiBot valuations. |
-| `LUCAS_HUMBLEWORTH_API_KEY` | API key for HumbleWorth valuations. |
+| `LUCAS_HUMBLEWORTH_API_KEY` | Optional API key for HumbleWorth valuations (currently not required). |
 
 Create a `.env` file based on `.env.example` and fill in your credentials.
 

--- a/lucas_project/modules/4_valuation.py
+++ b/lucas_project/modules/4_valuation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import httpx
 
 from lucas_project.core import (
     LLMCache,
@@ -12,6 +13,7 @@ from lucas_project.core import (
     rate_limiter,
     retry,
     circuit_breaker,
+    get_settings,
 )
 
 logger = get_logger(__name__)
@@ -30,8 +32,21 @@ async def fetch_estibot(domain: str) -> float:
 @circuit_breaker(5, 60)
 @rate_limiter(max_calls=5, period=1.0)
 async def fetch_humbleworth(domain: str) -> float:
-    await asyncio.sleep(0)
-    return 80.0
+    settings = get_settings()
+    url = "https://valuation.humbleworth.com/api/valuation"
+    payload = {"domains": [domain]}
+    headers = {"Content-Type": "application/json"}
+    if settings.humbleworth_api_key:
+        headers["Authorization"] = settings.humbleworth_api_key
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(url, headers=headers, json=payload, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+    valuations = data.get("valuations", [])
+    if valuations:
+        val = valuations[0]
+        return float(val.get("marketplace", 0))
+    return 0.0
 
 
 @retry(3, backoff=1.0)
@@ -53,7 +68,9 @@ SERVICE_FUNCS = {
 async def run() -> None:
     """Value available domains using external services."""
     async with get_db() as db:
-        async with db.execute("SELECT id, domain FROM domains WHERE status = 'available'") as cursor:
+        async with db.execute(
+            "SELECT id, domain FROM domains WHERE status = 'available'"
+        ) as cursor:
             rows = await cursor.fetchall()
         for row in rows:
             for service, func in SERVICE_FUNCS.items():


### PR DESCRIPTION
## Summary
- add placeholder for `LUCAS_HUMBLEWORTH_API_KEY` in `.env.example`
- clarify in README that HumbleWorth key is optional
- call HumbleWorth public endpoint in valuation module

## Testing
- `ruff format lucas_project/modules/4_valuation.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68461d841cc8832083a6be721dbd8797